### PR TITLE
feat: get calendar events for next 7 days and brief on upcoming events

### DIFF
--- a/src/generate_brief.sh
+++ b/src/generate_brief.sh
@@ -53,6 +53,7 @@ fi
 CURRENT_DATE=$(date +"%Y-%m-%d %H:%M:%S")
 TODAY=$(date +"%Y-%m-%d")
 TOMORROW=$(date -d "tomorrow" +"%Y-%m-%d")
+NEXT_WEEK=$(date -d "+7 days" +"%Y-%m-%d")
 DATE_TWO_WEEKS_AGO=$(date -d "14 days ago" +"%Y-%m-%d")
 YEAR=$(date +"%Y")
 MONTH=$(date +"%m")
@@ -68,7 +69,7 @@ BRIEF_OUTPUT_FILE="${BRIEF_OUTPUT_DIR}/${DAY}.md"
 
 # Run the calendar command and save output to daily log file
 echo "=== Calendar data collected on ${CURRENT_DATE} ===" > "${CALENDAR_LOG_FILE}"
-eval "gcalcli ${CALENDAR_ARGS} agenda $DATE_TWO_WEEKS_AGO $TOMORROW" >> "${CALENDAR_LOG_FILE}" 2>&1
+eval "gcalcli ${CALENDAR_ARGS} agenda $DATE_TWO_WEEKS_AGO $NEXT_WEEK" >> "${CALENDAR_LOG_FILE}" 2>&1
 echo "" >> "${CALENDAR_LOG_FILE}"  # Add empty line for readability
 
 echo "Calendar data collected and saved to ${CALENDAR_LOG_FILE}"
@@ -97,13 +98,14 @@ echo "Generating daily brief with aider..."
 aider --message "Based on the provided journal entries and calendar data, please generate a concise daily brief and gameplan for today (${TODAY}). 
 
 Instructions:
-- The calendar output covers the past 2 weeks through tomorrow
+- The calendar output covers the past 2 weeks through the next 7 days (until ${NEXT_WEEK})
 - Mark any recurring events scheduled for today as 'recurring' in the brief
 - Focus on actionable items and priorities for today
 - Include relevant context from recent journal entries
+- Also provide a brief overview of upcoming events in the next 7 days
 - Format as GitHub markdown with proper headers, bullet points, and sections
 - Use markdown formatting like ## for headers, - for bullet points, **bold** for emphasis
-- Structure with clear sections like ## Today's Schedule, ## Action Items, ## Notes, etc.
+- Structure with clear sections like ## Today's Schedule, ## Upcoming Events (Next 7 Days), ## Action Items, ## Notes, etc.
 - Make it visually appealing and easy to read in markdown viewers
 
 Please populate the brief output file with a well-formatted GitHub markdown daily brief." --yes "${BRIEF_INPUT_FILE}" "${BRIEF_OUTPUT_FILE}"

--- a/tests/test_generate_brief.sh
+++ b/tests/test_generate_brief.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Test script to verify changes to generate_brief.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATE_BRIEF_SCRIPT="${SCRIPT_DIR}/../src/generate_brief.sh"
+
+# Test 1: Verify NEXT_WEEK variable is defined
+test_next_week_defined() {
+    if grep -q 'NEXT_WEEK=$(date -d "+7 days"' "$GENERATE_BRIEF_SCRIPT"; then
+        echo "✓ Test 1 PASSED: NEXT_WEEK variable is defined"
+        return 0
+    else
+        echo "✗ Test 1 FAILED: NEXT_WEEK variable is not defined"
+        return 1
+    fi
+}
+
+# Test 2: Verify calendar command uses NEXT_WEEK instead of TOMORROW
+test_calendar_uses_next_week() {
+    if grep -q 'agenda $DATE_TWO_WEEKS_AGO $NEXT_WEEK' "$GENERATE_BRIEF_SCRIPT"; then
+        echo "✓ Test 2 PASSED: Calendar command uses NEXT_WEEK"
+        return 0
+    else
+        echo "✗ Test 2 FAILED: Calendar command does not use NEXT_WEEK"
+        return 1
+    fi
+}
+
+# Test 3: Verify aider message includes upcoming events briefing
+test_aider_message_upcoming_events() {
+    if grep -q 'upcoming events in the next 7 days' "$GENERATE_BRIEF_SCRIPT"; then
+        echo "✓ Test 3 PASSED: Aider message includes upcoming events instruction"
+        return 0
+    else
+        echo "✗ Test 3 FAILED: Aider message does not include upcoming events instruction"
+        return 1
+    fi
+}
+
+# Test 4: Verify aider message includes NEXT_WEEK in instructions
+test_aider_message_includes_next_week() {
+    if grep -q 'through the next 7 days (until ${NEXT_WEEK})' "$GENERATE_BRIEF_SCRIPT"; then
+        echo "✓ Test 4 PASSED: Aider message includes NEXT_WEEK in instructions"
+        return 0
+    else
+        echo "✗ Test 4 FAILED: Aider message does not include NEXT_WEEK in instructions"
+        return 1
+    fi
+}
+
+# Test 5: Verify aider message includes Upcoming Events section
+test_aider_message_upcoming_section() {
+    if grep -q '## Upcoming Events (Next 7 Days)' "$GENERATE_BRIEF_SCRIPT"; then
+        echo "✓ Test 5 PASSED: Aider message includes Upcoming Events section"
+        return 0
+    else
+        echo "✗ Test 5 FAILED: Aider message does not include Upcoming Events section"
+        return 1
+    fi
+}
+
+# Run all tests
+echo "Running tests for generate_brief.sh changes..."
+echo ""
+
+FAILED=0
+
+test_next_week_defined || FAILED=1
+test_calendar_uses_next_week || FAILED=1
+test_aider_message_upcoming_events || FAILED=1
+test_aider_message_includes_next_week || FAILED=1
+test_aider_message_upcoming_section || FAILED=1
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
This PR addresses issue #1 by modifying the `generate_brief.sh` script to:
1. Get calendar events for the next 7 days (instead of just tomorrow)
2. Ask aider to brief on upcoming events as well

## Changes Made
- Added `NEXT_WEEK` variable to calculate the date 7 days from now
- Updated the calendar command to fetch events up to next week (`$NEXT_WEEK`) instead of just tomorrow (`$TOMORROW`)
- Updated the aider message to request briefing on upcoming events in the next 7 days
- Added a new section "Upcoming Events (Next 7 Days)" in the brief structure
- Added tests to verify the changes

## Testing
- Created `tests/test_generate_brief.sh` with 5 test cases that verify:
  - NEXT_WEEK variable is defined
  - Calendar command uses NEXT_WEEK
  - Aider message includes upcoming events instruction
  - Aider message includes NEXT_WEEK in instructions
  - Aider message includes Upcoming Events section

All tests pass successfully.

## Notes
- The calendar output now covers past 2 weeks through the next 7 days (until ${NEXT_WEEK})
- The daily brief will now include an "Upcoming Events (Next 7 Days)" section

Fixes #1

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c24d78b85d0c48b99c34ba7ae357135c)